### PR TITLE
feat: ability to specify additional initContainers, env vars, and volumes in values.yaml

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -55,6 +55,9 @@ spec:
           env:
             - name: OCTANT_HTTP_PORT
               value: {{ .Values.service.port | quote }}
+          {{- if .Values.extraEnvs }}
+            {{- toYaml .Values.extraEnvs | nindent 12 }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -21,6 +21,10 @@ spec:
       serviceAccountName: {{ include "octant.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.extraInitContainers }}
+      initContainers:
+        {{- toYaml .Values.extraInitContainers | nindent 8 }}
+      {{- end }}
       containers:
         {{- if .Values.keycloakGatekeeper.enabled }}
         - name: sso

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -73,11 +73,17 @@ spec:
           volumeMounts:
             - name: tmp-mount
               mountPath: /tmp
+          {{- if .Values.extraVolumeMounts }}
+            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
         - name: tmp-mount
           emptyDir: {}
+      {{- if .Values.extraVolumes }}
+        {{- toYaml .Values.extraVolumes | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -9,6 +9,17 @@ keycloakGatekeeper:
   clientSecret: ~
   port: ~
 
+## Additional environment variables to set
+extraEnvs: []
+# extraEnvs:
+#   - name: OCTANT_PLUGIN_PATH
+#     value: /var/lib/octant-plugins
+#   - name: FOO
+#     valueFrom:
+#       secretKeyRef:
+#         key: FOO
+#         name: secret-resource
+
 imagePullSecrets: ~
 
 nameOverride: ""

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -20,6 +20,16 @@ extraEnvs: []
 #         key: FOO
 #         name: secret-resource
 
+extraVolumeMounts: []
+## Additional volumeMounts to the main container.
+#  - name: plugin-dir
+#   mountPath: /var/lib/octant-plugins
+
+extraVolumes: []
+## Additional volumes to the pod.
+#  - name: plugin-dir
+#    emptyDir: {}
+
 extraInitContainers: []
 ## Containers, which are run before the app containers are started.
 # - name: init-myservice

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -20,6 +20,12 @@ extraEnvs: []
 #         key: FOO
 #         name: secret-resource
 
+extraInitContainers: []
+## Containers, which are run before the app containers are started.
+# - name: init-myservice
+#   image: busybox
+#   command: ['sh', '-c', 'until nslookup myservice; do echo waiting for myservice; sleep 2; done;']
+
 imagePullSecrets: ~
 
 nameOverride: ""


### PR DESCRIPTION
For example, a user could supply some additional octant configuration via env vars:
### User Variables
* `KUBECONFIG` - set to non-empty location if you want to set KUBECONFIG with an environment variable.
* `OCTANT_NAMESPACE` - initial namespace to load when Octant starts.
* `OCTANT_CONTEXT` - intial context to load when Octant starts.
* `OCTANT_DISABLE_CLUSTER_OVERVIEW` - disable cluster overview when a context does not have cluster level permissions.
* `OCTANT_PLUGIN_PATH` - add a plugin directory or multiple directories separated by `:`. Plugins will load by default from `$HOME/.config/octant/plugins`

and/or use an initContainer with a shared emptyDir volume to download and install plugins