### PR TITLE
Issue #9: Add override for default ClusterRole rules

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.16.1+1
+version: 0.16.2+1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/helm/templates/clusterrole.yaml
+++ b/helm/templates/clusterrole.yaml
@@ -6,36 +6,42 @@ metadata:
   labels:
   name: octant-readonly-everything
 rules:
-- apiGroups:
-  - ""
-  resources: ["*"]
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - extensions
-  resources: ["*"]
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apiextensions.k8s.io
-  resources: ["*"]
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apps
-  resources: ["*"]
-  verbs:
-  - get
-  - list
-  - watch
+{{- if .Values.clusterRole.rules }}
+{{- with .Values.clusterRole.rules }}
+{{ toYaml . | indent 2 }}
+{{- end }}
+{{- else }}
+  - apiGroups:
+      - ""
+    resources: ["*"]
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources: ["*"]
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources: ["*"]
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources: ["*"]
+    verbs:
+      - get
+      - list
+      - watch
 {{- with .Values.clusterRole.additionalRules }}
-{{ toYaml . }}
+{{ toYaml . | indent 2 }}
+{{- end }}
 {{- end }}
 
 ---

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -49,6 +49,9 @@ serviceAccount:
   name: octant-readonly-sa
 
 clusterRole:
+  # Override the entire set of cluster roles, if not specified a default set of read-only-everything rules will be created
+  rules: ~
+  # Add additional rules to the default read-only-everything, this is ignored if clusterRole.rules is provided.
   additionalRules: ~
 
 plugins:


### PR DESCRIPTION
Ability to specify the default rules. For example, this will remove the ability to view secrets and a few other things that you probably don't want everyone to see:
```
clusterRole:
  rules:
    - apiGroups:
      - '*'
      resources:
      - configmaps
      - endpoints
      - events
      - namespaces
      - nodes
      - nodes/status
      - persistentvolumeclaims
      - persistentvolumeclaims/status
      - persistentvolumes
      - persistentvolumes/status
      - pods
      - pods/log
      - pods/status
      - replicationcontrollers
      - replicationcontrollers/status
      - resourcequotas
      - resourcequotas/status
      - services
      - services/status
      - daemonsets
      - daemonsets/status
      - deployments
      - deployments/status
      - replicasets
      - replicasets/status
      - statefulsets
      - statefulsets/status
      - jobs
      - jobs/status
      - cronjobs
      - cronjobs/status
      - ingresses
      - ingresses/status
      - replicasets
      - replicasets/status
      - storageclasses
      - volumeattachments
      - volumeattachments/status
      verbs:
      - get
      - list
      - watch 
```