### PR TITLE
Update Octant to version 0.25.1 and multiplatform Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,22 @@
-FROM alpine:3 AS builder
+FROM --platform=linux/arm64 alpine:3 AS add-arm64
+ENV OCTANT_VERSION=0.25.1
+ENV OCTANT_CHECKSUM=a3eb4973a0c869267e3916bd43e0b41b2bbc73b898376b795a617299c7b2a623
+ADD https://github.com/vmware-tanzu/octant/releases/download/v${OCTANT_VERSION}/octant_${OCTANT_VERSION}_Linux-arm64.tar.gz /tmp/octant.tar.gz
 
-ENV OCTANT_VERSION=0.25.0
-ENV OCTANT_CHECKSUM=a90e489858133ffdb88c64b2ed68a1013720eb966e36958e8008ba8d6dce2e76
+FROM --platform=linux/arm64 alpine:3 AS add-amd64
+ENV OCTANT_VERSION=0.25.1
+ENV OCTANT_CHECKSUM=b12bb6752e43f4e0fe54278df8e98dee3439c4066f66cdb7a0ca4a1c7d8eaa1e
+ADD https://github.com/vmware-tanzu/octant/releases/download/v${OCTANT_VERSION}/octant_${OCTANT_VERSION}_Linux-64bit.tar.gz /tmp/octant.tar.gz
 
-RUN apk update && \
-    apk add \
-      ca-certificates \
-      xdg-utils \
-      && \
-    wget --quiet --output-document /tmp/octant.tar.gz \
-        https://github.com/vmware-tanzu/octant/releases/download/v${OCTANT_VERSION}/octant_${OCTANT_VERSION}_Linux-64bit.tar.gz && \
-    sha256sum /tmp/octant.tar.gz | grep "$OCTANT_CHECKSUM" && \
+ARG TARGETARCH
+
+FROM add-${TARGETARCH} as builder
+RUN sha256sum /tmp/octant.tar.gz | grep "$OCTANT_CHECKSUM" && \
     if [[ $? -ne 0 ]]; then echo "Bad checksum"; exit 444; fi && \
     tar -xzvf /tmp/octant.tar.gz --strip 1 -C /opt
 
-COPY docker-entrypoint.sh /
-
-
 FROM alpine:3
-
-WORKDIR /tmp
-
 RUN addgroup -g 2000 -S octant && adduser -u 1000 -h /home/octant -G octant -S octant
-
 COPY --from=builder /opt/octant /opt/octant
 COPY docker-entrypoint.sh /
-
 ENTRYPOINT /docker-entrypoint.sh

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -6,8 +6,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.25.0
+version: 0.25.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.25.0
+appVersion: 0.25.1

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,7 +1,7 @@
 replicas: 1
 
 image:
-  fullname: aleveille/octant-dashboard:v0.25.0
+  fullname: aleveille/octant-dashboard:v0.25.1
   pullPolicy: IfNotPresent
 
 keycloakGatekeeper:


### PR DESCRIPTION
Hi,

I updated Octant to the latest and greatest version `0.25.1`.

I also updated the Dockerfile with a few changes:

 - I use the `ADD` Dockerfile instruction instead of `wget`
 - I don't install xdg-utils anymore because it's not required. I guess it was used at some point because octant can open the web-browser automatically but in the current version, octant is started with the `--disable-open-browser` option.
 - It supports two architectures, `arm64` and `amd64`. It could support more but I'm not sure there is a need. The `arm64` architecture is starting to be popular since Apple moved to Arm (starting with their M1 chipset).

You may need Docker buildx to build the image. I don't know how is your build process, but if you plan to use Github Actions, you could look at [the workflow file I created on my fork]( https://github.com/SINTEF/octant-dashboard-turnkey/blob/1dc9048028295a9265c5d4356cf6585af13acdde/.github/workflows/docker-images.yaml). It's relatively straightforward.

I didn't update the `repo/index.yaml` file because I'm not sure how you generate it and it needs to have a Github release.

I hope everything is fine. Have a nice day and thanks for this project 😊